### PR TITLE
Fix/code arena minimal

### DIFF
--- a/contracts/interfaces/ILineOfCredit.sol
+++ b/contracts/interfaces/ILineOfCredit.sol
@@ -83,6 +83,8 @@ interface ILineOfCredit {
   error NotInsolvent(address module);
   error NotLiquidatable();
   error AlreadyInitialized();
+  error RepayingExcessRevenue(uint256 totalAvailable);
+
 
 
   // Fully public functions

--- a/contracts/interfaces/ILineOfCredit.sol
+++ b/contracts/interfaces/ILineOfCredit.sol
@@ -83,7 +83,7 @@ interface ILineOfCredit {
   error NotInsolvent(address module);
   error NotLiquidatable();
   error AlreadyInitialized();
-  error RepayingExcessRevenue(uint256 totalAvailable);
+  error RepayAmountExceedsDebt(uint256 totalAvailable);
 
 
 

--- a/contracts/interfaces/ISpigot.sol
+++ b/contracts/interfaces/ISpigot.sol
@@ -60,6 +60,8 @@ interface ISpigot {
 
     error BadSetting();
 
+    error InvalidRevenueContract();
+
     // ops funcs
 
     function claimRevenue(

--- a/contracts/interfaces/ISpigotedLine.sol
+++ b/contracts/interfaces/ISpigotedLine.sol
@@ -8,7 +8,7 @@ interface ISpigotedLine {
     // Mainly used to log debt that is paid via Spigot directly vs other sources. Without this event it's a lot harder to parse that offchain.
     event RevenuePayment(address indexed token, uint256 indexed amount);
 
-    error UsingExcessReserves(uint256 totalAvailable);
+    error ReservesOverdrawn(uint256 totalAvailable);
 
     // @notice Log many revenue tokens were traded for credit tokens.
     // @notice differs from Revenue Payment because we trade revenue at different times from repaying with revenue

--- a/contracts/interfaces/ISpigotedLine.sol
+++ b/contracts/interfaces/ISpigotedLine.sol
@@ -8,6 +8,8 @@ interface ISpigotedLine {
     // Mainly used to log debt that is paid via Spigot directly vs other sources. Without this event it's a lot harder to parse that offchain.
     event RevenuePayment(address indexed token, uint256 indexed amount);
 
+    error UsingExcessReserves(uint256 totalAvailable);
+
     // @notice Log many revenue tokens were traded for credit tokens.
     // @notice differs from Revenue Payment because we trade revenue at different times from repaying with revenue
     // @dev Can you use to figure out price of revenue tokens offchain since we only have an oracle for credit tokens

--- a/contracts/modules/credit/LineOfCredit.sol
+++ b/contracts/modules/credit/LineOfCredit.sol
@@ -140,7 +140,7 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
 
 
     /// see ILineOfCredit.declareInsolvent
-    function declareInsolvent() external whileBorrowing returns(bool) {
+    function declareInsolvent() external returns(bool) {
         if(arbiter != msg.sender) { revert CallerAccessDenied(); }
         if(LineLib.STATUS.LIQUIDATABLE != _updateStatus(_healthcheck())) {
             revert NotLiquidatable();

--- a/contracts/modules/credit/SpigotedLine.sol
+++ b/contracts/modules/credit/SpigotedLine.sol
@@ -142,7 +142,7 @@ contract SpigotedLine is ISpigotedLine, LineOfCredit, ReentrancyGuard {
       }
 
       if(amount > unusedTokens[credit.token]) {
-        revert UsingExcessReserves(unusedTokens[credit.token]);
+        revert ReservesOverdrawn(unusedTokens[credit.token]);
       }
 
       credits[id] = _repay(_accrue(credit, id), id, amount);

--- a/contracts/modules/credit/SpigotedLine.sol
+++ b/contracts/modules/credit/SpigotedLine.sol
@@ -140,11 +140,14 @@ contract SpigotedLine is ISpigotedLine, LineOfCredit, ReentrancyGuard {
       if (msg.sender != borrower && msg.sender != credit.lender) {
         revert CallerAccessDenied();
       }
-      require(amount <= unusedTokens[credit.token]); // unused
-      require(amount <= credit.principal + credit.interestAccrued); // debt
-      unusedTokens[credit.token] -= amount;
+
+      if(amount > unusedTokens[credit.token]) {
+        revert UsingExcessReserves(unusedTokens[credit.token]);
+      }
 
       credits[id] = _repay(_accrue(credit, id), id, amount);
+
+      unusedTokens[credit.token] -= amount;
 
       emit RevenuePayment(credit.token, amount);
 

--- a/contracts/modules/credit/SpigotedLine.sol
+++ b/contracts/modules/credit/SpigotedLine.sol
@@ -140,7 +140,7 @@ contract SpigotedLine is ISpigotedLine, LineOfCredit, ReentrancyGuard {
       if (msg.sender != borrower && msg.sender != credit.lender) {
         revert CallerAccessDenied();
       }
-      require(amount <= unusedTokens[credit.token]);
+      require(amount <= credit.principal + credit.interestAccrued);
       unusedTokens[credit.token] -= amount;
 
       credits[id] = _repay(_accrue(credit, id), id, amount);

--- a/contracts/modules/credit/SpigotedLine.sol
+++ b/contracts/modules/credit/SpigotedLine.sol
@@ -140,7 +140,8 @@ contract SpigotedLine is ISpigotedLine, LineOfCredit, ReentrancyGuard {
       if (msg.sender != borrower && msg.sender != credit.lender) {
         revert CallerAccessDenied();
       }
-      require(amount <= credit.principal + credit.interestAccrued);
+      require(amount <= unusedTokens[credit.token]); // unused
+      require(amount <= credit.principal + credit.interestAccrued); // debt
       unusedTokens[credit.token] -= amount;
 
       credits[id] = _repay(_accrue(credit, id), id, amount);

--- a/contracts/tests/Escrow.t.sol
+++ b/contracts/tests/Escrow.t.sol
@@ -370,6 +370,14 @@ contract EscrowTest is Test {
         escrow.addCollateral(1000, address(token4626));
     }
 
+    function test_can_send_eth_and_token() public {
+        uint borrowerBalance = borrower.balance;
+        uint borrowerTokenBalance = supportedToken1.balanceOf(borrower);
+        uint escrowBalance = address(escrow).balance;
+        vm.expectRevert(LineLib.EthSentWithERC20.selector);
+        escrow.addCollateral{value: mintAmount}(mintAmount, address(supportedToken1));
+    }
+
 
     
 

--- a/contracts/tests/SecuredLine.t.sol
+++ b/contracts/tests/SecuredLine.t.sol
@@ -364,7 +364,7 @@ contract SecuredLineTest is Test {
 
 // declareInsolvent
     function test_must_be_in_debt_to_go_insolvent() public {
-        vm.expectRevert(ILineOfCredit.NotBorrowing.selector);
+        vm.expectRevert(ILineOfCredit.NotLiquidatable.selector);
         line.declareInsolvent();
     }
 

--- a/contracts/tests/Spigot.t.sol
+++ b/contracts/tests/Spigot.t.sol
@@ -232,7 +232,7 @@ contract SpigotTest is Test {
         assertSpigotSplits(address(token), totalRevenue);
     }
 
-    function test_claimRevenue_pushPaymentToken_bad_revenue_contract(uint256 totalRevenue) public {
+    function test_claimRevenue_fails_on_contract_with_no_settings(uint256 totalRevenue) public {
         if (totalRevenue == 0 || totalRevenue > MAX_REVENUE) return;
 
         // send revenue token directly to spigot (push)

--- a/contracts/tests/Spigot.t.sol
+++ b/contracts/tests/Spigot.t.sol
@@ -232,6 +232,21 @@ contract SpigotTest is Test {
         assertSpigotSplits(address(token), totalRevenue);
     }
 
+    function test_claimRevenue_pushPaymentToken_bad_revenue_contract(uint256 totalRevenue) public {
+        if (totalRevenue == 0 || totalRevenue > MAX_REVENUE) return;
+
+        // send revenue token directly to spigot (push)
+        token.mint(address(spigot), totalRevenue);
+        assertEq(token.balanceOf(address(spigot)), totalRevenue);
+
+        bytes memory claimData;
+        vm.expectRevert(ISpigot.InvalidRevenueContract.selector);
+        spigot.claimRevenue(address(0), address(token), claimData);
+
+        vm.expectRevert(ISpigot.InvalidRevenueContract.selector);
+        spigot.claimRevenue(makeAddr("villain"), address(token), claimData);
+    }
+
     function test_claimRevenue_pullPaymentToken(uint256 totalRevenue) public {
         if (totalRevenue == 0 || totalRevenue > MAX_REVENUE) return;
         _initSpigot(

--- a/contracts/tests/SpigotedLine.t.sol
+++ b/contracts/tests/SpigotedLine.t.sol
@@ -284,7 +284,12 @@ contract SpigotedLineTest is Test {
       
       assertEq(p, lentAmount); // nothing repaid
 
-      vm.expectRevert();
+      vm.expectRevert(
+        abi.encodeWithSelector(
+         ISpigotedLine.UsingExcessReserves.selector,
+         0
+        )
+      );
       line.useAndRepay(1);
       vm.stopPrank();
     }
@@ -1117,8 +1122,15 @@ contract SpigotedLineTest is Test {
       assertEq(principalBeforeRepaying, lentAmount);
 
       // 3. Use and repay debt with previously claimed and traded revenue (largeRevenueAmount = 2 ether)
-      vm.prank(lender);
-      vm.expectRevert(bytes(""));
+      vm.startPrank(lender);
+      
+      vm.expectRevert(
+        abi.encodeWithSelector(
+         ILineOfCredit.RepayingExcessRevenue.selector,
+         principalBeforeRepaying
+        )
+      );
+
       line.useAndRepay(largeRevenueAmount);
     }
 }

--- a/contracts/tests/SpigotedLine.t.sol
+++ b/contracts/tests/SpigotedLine.t.sol
@@ -286,7 +286,7 @@ contract SpigotedLineTest is Test {
 
       vm.expectRevert(
         abi.encodeWithSelector(
-         ISpigotedLine.UsingExcessReserves.selector,
+         ISpigotedLine.ReservesOverdrawn.selector,
          0
         )
       );
@@ -1126,7 +1126,7 @@ contract SpigotedLineTest is Test {
       
       vm.expectRevert(
         abi.encodeWithSelector(
-         ILineOfCredit.RepayingExcessRevenue.selector,
+         ILineOfCredit.RepayAmountExceedsDebt.selector,
          principalBeforeRepaying
         )
       );

--- a/contracts/tests/SpigotedLine.t.sol
+++ b/contracts/tests/SpigotedLine.t.sol
@@ -696,7 +696,7 @@ contract SpigotedLineTest is Test {
 
     function test_cant_sweep_empty_tokens() public {
       vm.expectRevert(abi.encodeWithSelector(
-        SpigotedLineLib.UsedExcessTokens.selector,
+        SpigotedLineLib.ReservesOverdrawn.selector,
         address(creditToken),
         0
       ));

--- a/contracts/utils/CreditLib.sol
+++ b/contracts/utils/CreditLib.sol
@@ -50,7 +50,7 @@ library CreditLib {
 
   error PositionExists();
 
-  error RepayingExcessRevenue(uint256 totalAvailable);
+  error RepayAmountExceedsDebt(uint256 totalAvailable);
 
 
   /**
@@ -176,7 +176,7 @@ library CreditLib {
     returns (ILineOfCredit.Credit memory)
   { unchecked {
       if(amount > credit.principal + credit.interestAccrued) {
-        revert RepayingExcessRevenue(credit.principal + credit.interestAccrued);
+        revert RepayAmountExceedsDebt(credit.principal + credit.interestAccrued);
       }
 
       if (amount <= credit.interestAccrued) {

--- a/contracts/utils/CreditLib.sol
+++ b/contracts/utils/CreditLib.sol
@@ -13,12 +13,12 @@ import { LineLib } from "./LineLib.sol";
  */
 library CreditLib {
 
-    event AddCredit(
-        address indexed lender,
-        address indexed token,
-        uint256 indexed deposit,
-        bytes32 id
-    );
+  event AddCredit(
+      address indexed lender,
+      address indexed token,
+      uint256 indexed deposit,
+      bytes32 id
+  );
 
   /// @notice Emits data re Lender removes funds (principal) - there is no corresponding function, just withdraw()
   event WithdrawDeposit(bytes32 indexed id, uint256 indexed amount);
@@ -49,6 +49,8 @@ library CreditLib {
   error NoTokenPrice();
 
   error PositionExists();
+
+  error RepayingExcessRevenue(uint256 totalAvailable);
 
 
   /**
@@ -173,6 +175,10 @@ library CreditLib {
     external
     returns (ILineOfCredit.Credit memory)
   { unchecked {
+      if(amount > credit.principal + credit.interestAccrued) {
+        revert RepayingExcessRevenue(credit.principal + credit.interestAccrued);
+      }
+
       if (amount <= credit.interestAccrued) {
           credit.interestAccrued -= amount;
           credit.interestRepaid += amount;

--- a/contracts/utils/LineLib.sol
+++ b/contracts/utils/LineLib.sol
@@ -14,6 +14,7 @@ import { Denominations } from "chainlink/Denominations.sol";
 library LineLib {
     using SafeERC20 for IERC20;
 
+    error EthSentWithERC20();
     error TransferFailed();
     error BadToken();
 
@@ -66,6 +67,7 @@ library LineLib {
     {
         if(token == address(0)) { revert TransferFailed(); }
         if(token != Denominations.ETH) { // ERC20
+            if (msg.value >= 0) { revert EthSentWithERC20(); }
             IERC20(token).safeTransferFrom(sender, address(this), amount);
         } else { // ETH
             if(msg.value < amount) { revert TransferFailed(); }

--- a/contracts/utils/LineLib.sol
+++ b/contracts/utils/LineLib.sol
@@ -67,7 +67,7 @@ library LineLib {
     {
         if(token == address(0)) { revert TransferFailed(); }
         if(token != Denominations.ETH) { // ERC20
-            if (msg.value >= 0) { revert EthSentWithERC20(); }
+            if (msg.value > 0) { revert EthSentWithERC20(); }
             IERC20(token).safeTransferFrom(sender, address(this), amount);
         } else { // ETH
             if(msg.value < amount) { revert TransferFailed(); }

--- a/contracts/utils/SpigotLib.sol
+++ b/contracts/utils/SpigotLib.sol
@@ -32,6 +32,8 @@ library SpigotLib {
         address token,
         bytes calldata data
     ) public returns (uint256 claimed) {
+        if (self.settings[revenueContract].transferOwnerFunction == bytes4(0)) { revert InvalidRevenueContract(); }
+
         uint256 existingBalance = LineLib.getBalance(token);
         if (self.settings[revenueContract].claimFunction == bytes4(0)) {
             // push payments
@@ -371,4 +373,6 @@ library SpigotLib {
     error CallerAccessDenied();
 
     error BadSetting();
+
+    error InvalidRevenueContract();
 }

--- a/contracts/utils/SpigotedLineLib.sol
+++ b/contracts/utils/SpigotedLineLib.sol
@@ -24,7 +24,7 @@ library SpigotedLineLib {
 
     error NotInsolvent(address module);
 
-    error UsedExcessTokens(address token, uint256 amountAvailable);
+    error ReservesOverdrawn(address token, uint256 amountAvailable);
 
 
     event TradeSpigotRevenue(
@@ -102,7 +102,7 @@ library SpigotedLineLib {
 
           // used more tokens than we had in revenue reserves.
           // prevent borrower from pulling idle lender funds to repay other lenders
-          if(diff > unused) revert UsedExcessTokens(claimToken,  unused); 
+          if(diff > unused) revert ReservesOverdrawn(claimToken,  unused); 
           // reduce reserves by consumed amount
           else return (
             tokensBought,
@@ -215,11 +215,10 @@ library SpigotedLineLib {
    * @return - whether or not spigot was released
   */
     function sweep(address to, address token, uint256 amount, LineLib.STATUS status, address borrower, address arbiter) external returns (bool) {
-        if(amount == 0) { revert UsedExcessTokens(token, 0); }
+        if(amount == 0) { revert ReservesOverdrawn(token, 0); }
 
         if (status == LineLib.STATUS.REPAID && msg.sender == borrower) {
             return LineLib.sendOutTokenOrETH(token, to, amount);
-
         }
 
         if (


### PR DESCRIPTION
- checks that `amount <= credit.principal + credit.interestAccrued` in `useAndRepay`
- prevent user sending eth when receiving an ERC20
- checks that revenue contract settings exist in claimRevenue
- remove whileBorrowing modifier from `declareInsolvent()`