### PR TITLE
Fix/spigoted line 0x access

### DIFF
--- a/contracts/modules/credit/LineOfCredit.sol
+++ b/contracts/modules/credit/LineOfCredit.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.8.9;
 
-import { Denominations } from "chainlink/Denominations.sol";
-import { IERC20 } from "openzeppelin/token/ERC20/IERC20.sol";
-import {SafeERC20}  from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
+import {Denominations} from "chainlink/Denominations.sol";
+import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
+import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 
 import {LineLib} from "../../utils/LineLib.sol";
 import {CreditLib} from "../../utils/CreditLib.sol";
@@ -38,14 +38,14 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
     LineLib.STATUS public status;
 
     /**
-   * @notice            - How to deploy a Line of Credit
-   * @dev               - A Borrower and a first Lender agree on terms. Then the Borrower deploys the contract using the constructor below.
-   *                      Later, both Lender and Borrower must call _mutualConsent() during addCredit() to actually enable funds to be deposited.
-   * @param oracle_     - The price oracle to use for getting all token values.
-   * @param arbiter_    - A neutral party with some special priviliges on behalf of Borrower and Lender.
-   * @param borrower_   - The debitor for all credit lines in this contract.
-   * @param ttl_        - The time to live for all credit lines for the Line of Credit facility (sets the maturity/term of the Line of Credit)
-  */
+     * @notice            - How to deploy a Line of Credit
+     * @dev               - A Borrower and a first Lender agree on terms. Then the Borrower deploys the contract using the constructor below.
+     *                      Later, both Lender and Borrower must call _mutualConsent() during addCredit() to actually enable funds to be deposited.
+     * @param oracle_     - The price oracle to use for getting all token values.
+     * @param arbiter_    - A neutral party with some special priviliges on behalf of Borrower and Lender.
+     * @param borrower_   - The debitor for all credit lines in this contract.
+     * @param ttl_        - The time to live for all credit lines for the Line of Credit facility (sets the maturity/term of the Line of Credit)
+     */
     constructor(
         address oracle_,
         address arbiter_,
@@ -55,20 +55,22 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
         oracle = IOracle(oracle_);
         arbiter = arbiter_;
         borrower = borrower_;
-        deadline = block.timestamp + ttl_;  //the deadline is the term/maturity/expiry date of the Line of Credit facility
+        deadline = block.timestamp + ttl_; //the deadline is the term/maturity/expiry date of the Line of Credit facility
         interestRate = new InterestRateCredit();
 
         emit DeployLine(oracle_, arbiter_, borrower_);
     }
 
-    function init() external virtual returns(LineLib.STATUS) {
-      if(status != LineLib.STATUS.UNINITIALIZED) { revert AlreadyInitialized(); }
-      return _updateStatus(_init());
+    function init() external virtual returns (LineLib.STATUS) {
+        if (status != LineLib.STATUS.UNINITIALIZED) {
+            revert AlreadyInitialized();
+        }
+        return _updateStatus(_init());
     }
 
-    function _init() internal virtual returns(LineLib.STATUS) {
-       // If no collateral or Spigot then Line of Credit is immediately active
-      return LineLib.STATUS.ACTIVE;
+    function _init() internal virtual returns (LineLib.STATUS) {
+        // If no collateral or Spigot then Line of Credit is immediately active
+        return LineLib.STATUS.ACTIVE;
     }
 
     ///////////////
@@ -76,17 +78,23 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
     ///////////////
 
     modifier whileActive() {
-        if(status != LineLib.STATUS.ACTIVE) { revert NotActive(); }
+        if (status != LineLib.STATUS.ACTIVE) {
+            revert NotActive();
+        }
         _;
     }
 
     modifier whileBorrowing() {
-        if(count == 0 || credits[ids[0]].principal == 0) { revert NotBorrowing(); }
+        if (count == 0 || credits[ids[0]].principal == 0) {
+            revert NotBorrowing();
+        }
         _;
     }
 
     modifier onlyBorrower() {
-        if(msg.sender != borrower) { revert CallerAccessDenied(); }
+        if (msg.sender != borrower) {
+            revert CallerAccessDenied();
+        }
         _;
     }
 
@@ -96,20 +104,20 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
      * @param id - position to pull lender address from for mutual consent agreement
     */
     modifier mutualConsentById(bytes32 id) {
-      if(_mutualConsent(borrower, credits[id].lender))  {
-        // Run whatever code is needed for the 2/2 consent
-        _;
-      }
+        if (_mutualConsent(borrower, credits[id].lender)) {
+            // Run whatever code is needed for the 2/2 consent
+            _;
+        }
     }
 
     /**
      * @notice - evaluates all covenants encoded in _healthcheck from different Line variants
      * @dev - updates `status` variable in storage if current status is diferent from existing status
      * @return - current health status of Line
-    */
+     */
     function healthcheck() external returns (LineLib.STATUS) {
         // can only check if the line has been initialized
-        require(uint(status) >= uint( LineLib.STATUS.ACTIVE));
+        require(uint256(status) >= uint256(LineLib.STATUS.ACTIVE));
         return _updateStatus(_healthcheck());
     }
 
@@ -122,8 +130,8 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
         // if line is in a final end state then do not run _healthcheck()
         LineLib.STATUS s = status;
         if (
-            s == LineLib.STATUS.REPAID ||               // end state - good
-            s == LineLib.STATUS.INSOLVENT               // end state - bad
+            s == LineLib.STATUS.REPAID || // end state - good
+            s == LineLib.STATUS.INSOLVENT // end state - bad
         ) {
             return s;
         }
@@ -134,33 +142,38 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
             return LineLib.STATUS.LIQUIDATABLE;
         }
 
-        // if nothing wrong, return to healthy ACTIVE state  
+        // if nothing wrong, return to healthy ACTIVE state
         return LineLib.STATUS.ACTIVE;
     }
 
-
     /// see ILineOfCredit.declareInsolvent
-    function declareInsolvent() external whileBorrowing returns(bool) {
-        if(arbiter != msg.sender) { revert CallerAccessDenied(); }
-        if(LineLib.STATUS.LIQUIDATABLE != _updateStatus(_healthcheck())) {
+    function declareInsolvent() external whileBorrowing returns (bool) {
+        if (arbiter != msg.sender) {
+            revert CallerAccessDenied();
+        }
+        if (LineLib.STATUS.LIQUIDATABLE != _updateStatus(_healthcheck())) {
             revert NotLiquidatable();
         }
 
-        if(_canDeclareInsolvent()) {
+        if (_canDeclareInsolvent()) {
             _updateStatus(LineLib.STATUS.INSOLVENT);
             return true;
         } else {
-          return false;
+            return false;
         }
     }
 
-    function _canDeclareInsolvent() internal virtual returns(bool) {
+    function _canDeclareInsolvent() internal virtual returns (bool) {
         // logic updated in Spigoted and Escrowed lines
         return true;
     }
 
     /// see ILineOfCredit.updateOutstandingDebt
-    function updateOutstandingDebt() external override returns (uint256, uint256) {
+    function updateOutstandingDebt()
+        external
+        override
+        returns (uint256, uint256)
+    {
         return _updateOutstandingDebt();
     }
 
@@ -173,21 +186,19 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
         if (len == 0) return (0, 0);
 
         bytes32 id;
-        address oracle_ = address(oracle);  // gas savings
+        address oracle_ = address(oracle); // gas savings
         address interestRate_ = address(interestRate); // gas savings
-        
+
         for (uint256 i; i < len; ++i) {
             id = ids[i];
 
             // null element in array from closing a position. skip for gas savings
-            if(id == bytes32(0)) { continue; }
+            if (id == bytes32(0)) {
+                continue;
+            }
 
-            (Credit memory c, uint256 _p, uint256 _i) = CreditLib.getOutstandingDebt(
-              credits[id],
-              id,
-              oracle_,
-              interestRate_
-            );
+            (Credit memory c, uint256 _p, uint256 _i) = CreditLib
+                .getOutstandingDebt(credits[id], id, oracle_, interestRate_);
             // update total outstanding debt
             principal += _p;
             interest += _i;
@@ -197,15 +208,15 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
     }
 
     /// see ILineOfCredit.accrueInterest
-    function accrueInterest() external override returns(bool) {
+    function accrueInterest() external override returns (bool) {
         uint256 len = ids.length;
         bytes32 id;
         for (uint256 i; i < len; ++i) {
-          id = ids[i];
-          Credit memory credit = credits[id];
-          credits[id] = _accrue(credit, id);
+            id = ids[i];
+            Credit memory credit = credits[id];
+            credits[id] = _accrue(credit, id);
         }
-        
+
         return true;
     }
 
@@ -215,8 +226,11 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
       @param credit - the lender position that is accruing interest
       @param id - the position id for credit position
     */
-    function _accrue(Credit memory credit, bytes32 id) internal returns(Credit memory) {
-      return CreditLib.accrue(credit, id, address(interestRate));
+    function _accrue(Credit memory credit, bytes32 id)
+        internal
+        returns (Credit memory)
+    {
+        return CreditLib.accrue(credit, id, address(interestRate));
     }
 
     /// see ILineOfCredit.addCredit
@@ -239,7 +253,9 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
         bytes32 id = _createCredit(lender, token, amount);
 
         require(interestRate.setRate(id, drate, frate));
-        
+
+        emit SetRates(id, drate, frate);
+
         return id;
     }
 
@@ -248,12 +264,7 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
         bytes32 id,
         uint128 drate,
         uint128 frate
-    )
-      external
-      override
-      mutualConsentById(id)
-      returns (bool)
-    {
+    ) external override mutualConsentById(id) returns (bool) {
         Credit memory credit = credits[id];
         credits[id] = _accrue(credit, id);
         require(interestRate.setRate(id, drate, frate));
@@ -263,18 +274,18 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
 
     /// see ILineOfCredit.increaseCredit
     function increaseCredit(bytes32 id, uint256 amount)
-      external
-      payable
-      override
-      whileActive
-      mutualConsentById(id)
-      returns (bool)
+        external
+        payable
+        override
+        whileActive
+        mutualConsentById(id)
+        returns (bool)
     {
         Credit memory credit = credits[id];
         credit = _accrue(credit, id);
 
         credit.deposit += amount;
-        
+
         credits[id] = credit;
 
         LineLib.receiveTokenOrETH(credit.token, credit.lender, amount);
@@ -309,7 +320,6 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
 
         return true;
     }
-
 
     /// see ILineOfCredit.depositAndRepay
     function depositAndRepay(uint256 amount)
@@ -346,14 +356,16 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
     {
         Credit memory credit = _accrue(credits[id], id);
 
-        if(amount > credit.deposit - credit.principal) { revert NoLiquidity(); }
+        if (amount > credit.deposit - credit.principal) {
+            revert NoLiquidity();
+        }
 
         credit.principal += amount;
 
         credits[id] = credit; // save new debt before healthcheck
 
         // ensure that borrowing doesnt cause Line to be LIQUIDATABLE
-        if(_updateStatus(_healthcheck()) != LineLib.STATUS.ACTIVE) { 
+        if (_updateStatus(_healthcheck()) != LineLib.STATUS.ACTIVE) {
             revert NotActive();
         }
 
@@ -374,7 +386,9 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
     {
         Credit memory credit = credits[id];
 
-        if(msg.sender != credit.lender) { revert CallerAccessDenied(); }
+        if (msg.sender != credit.lender) {
+            revert CallerAccessDenied();
+        }
 
         // accrues interest and transfers to Lender
         credits[id] = CreditLib.withdraw(_accrue(credit, id), id, amount);
@@ -388,19 +402,19 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
     function close(bytes32 id) external payable override returns (bool) {
         Credit memory credit = credits[id];
         address b = borrower; // gas savings
-        if(msg.sender != credit.lender && msg.sender != b) {
-          revert CallerAccessDenied();
+        if (msg.sender != credit.lender && msg.sender != b) {
+            revert CallerAccessDenied();
         }
 
         // ensure all money owed is accounted for. Accrue facility fee since prinicpal was paid off
         credit = _accrue(credit, id);
         uint256 facilityFee = credit.interestAccrued;
-        if(facilityFee > 0) {
-          // only allow repaying interest since they are skipping repayment queue.
-          // If principal still owed, _close() MUST fail
-          LineLib.receiveTokenOrETH(credit.token, b, facilityFee);
+        if (facilityFee > 0) {
+            // only allow repaying interest since they are skipping repayment queue.
+            // If principal still owed, _close() MUST fail
+            LineLib.receiveTokenOrETH(credit.token, b, facilityFee);
 
-          credit = _repay(credit, id, facilityFee);
+            credit = _repay(credit, id, facilityFee);
         }
 
         _close(credit, id); // deleted; no need to save to storage
@@ -413,15 +427,18 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
     //////////////////////
 
     /**
-      * @notice - updates `status` variable in storage if current status is diferent from existing status.
-      * @dev - privileged internal function. MUST check params and logic flow before calling
-      * @dev - does not save new status if it is the same as current status
-      * @return status - the current status of the line after updating
+     * @notice - updates `status` variable in storage if current status is diferent from existing status.
+     * @dev - privileged internal function. MUST check params and logic flow before calling
+     * @dev - does not save new status if it is the same as current status
+     * @return status - the current status of the line after updating
      */
-    function _updateStatus(LineLib.STATUS status_) internal returns(LineLib.STATUS) {
-      if(status == status_) return status_;
-      emit UpdateStatus(uint256(status_));
-      return (status = status_);
+    function _updateStatus(LineLib.STATUS status_)
+        internal
+        returns (LineLib.STATUS)
+    {
+        if (status == status_) return status_;
+        emit UpdateStatus(uint256(status_));
+        return (status = status_);
     }
 
     /**
@@ -431,29 +448,36 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
      * @param lender - address that will own and manage position
      * @param token - ERC20 token that is being lent and borrower
      * @param amount - amount of tokens lender will initially deposit
-    */
+     */
     function _createCredit(
         address lender,
         address token,
         uint256 amount
-    )
-        internal
-        returns (bytes32 id)
-    {
+    ) internal returns (bytes32 id) {
         id = CreditLib.computeId(address(this), lender, token);
         // MUST not double add the credit line. otherwise we can not _close()
-        if(credits[id].lender != address(0)) { revert PositionExists(); }
+        if (credits[id].lender != address(0)) {
+            revert PositionExists();
+        }
 
-        credits[id] = CreditLib.create(id, amount, lender, token, address(oracle));
+        credits[id] = CreditLib.create(
+            id,
+            amount,
+            lender,
+            token,
+            address(oracle)
+        );
 
         ids.push(id); // add lender to end of repayment queue
-        
-        unchecked { ++count; }
+
+        unchecked {
+            ++count;
+        }
 
         return id;
     }
 
-  /**
+    /**
    * @dev - Reduces `principal` and/or `interestAccrued` on a credit line.
             Expects checks for conditions of repaying and param sanitizing before calling
             e.g. early repayment of principal, tokens have actually been paid by borrower, etc.
@@ -462,10 +486,11 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
    * @param amount - amount of Credit Token being repaid on credit line
    * @return credit - position struct in memory with updated values
   */
-    function _repay(Credit memory credit, bytes32 id, uint256 amount)
-        internal
-        returns (Credit memory)
-    { 
+    function _repay(
+        Credit memory credit,
+        bytes32 id,
+        uint256 amount
+    ) internal returns (Credit memory) {
         credit = CreditLib.repay(credit, id, amount);
 
         // if credit line fully repaid then remove it from the repayment queue
@@ -480,8 +505,14 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
      * @dev - privileged internal function. MUST check params and logic flow before calling
      * @return credit - position struct in memory with updated values
      */
-    function _close(Credit memory credit, bytes32 id) internal virtual returns (bool) {
-        if(credit.principal > 0) { revert CloseFailedWithPrincipal(); }
+    function _close(Credit memory credit, bytes32 id)
+        internal
+        virtual
+        returns (bool)
+    {
+        if (credit.principal > 0) {
+            revert CloseFailedWithPrincipal();
+        }
 
         // return the Lender's funds that are being repaid
         if (credit.deposit + credit.interestRepaid > 0) {
@@ -496,10 +527,14 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
 
         // remove from active list
         ids.removePosition(id);
-        unchecked { --count; }
+        unchecked {
+            --count;
+        }
 
         // If all credit lines are closed the the overall Line of Credit facility is declared 'repaid'.
-        if (count == 0) { _updateStatus(LineLib.STATUS.REPAID); }
+        if (count == 0) {
+            _updateStatus(LineLib.STATUS.REPAID);
+        }
 
         emit CloseCreditPosition(id);
 
@@ -521,20 +556,18 @@ contract LineOfCredit is ILineOfCredit, MutualConsent {
             id = ids[i];
             if (p != id) {
                 if (
-                  id == bytes32(0) ||       // deleted element. In the middle of the q because it was closed.
-                  nextQSpot != lastSpot ||  // position already found. skip to find `p` asap
-                  credits[id].principal > 0 //`id` should be placed before `p` 
+                    id == bytes32(0) || // deleted element. In the middle of the q because it was closed.
+                    nextQSpot != lastSpot || // position already found. skip to find `p` asap
+                    credits[id].principal > 0 //`id` should be placed before `p`
                 ) continue;
-                nextQSpot = i;              // index of first undrawn line found
+                nextQSpot = i; // index of first undrawn line found
             } else {
-                if(nextQSpot == lastSpot) return true; // nothing to update
+                if (nextQSpot == lastSpot) return true; // nothing to update
                 // swap positions
-                ids[i] = ids[nextQSpot];    // id put into old `p` position
-                ids[nextQSpot] = p;         // p put at target index
-                return true; 
+                ids[i] = ids[nextQSpot]; // id put into old `p` position
+                ids[nextQSpot] = p; // p put at target index
+                return true;
             }
-          
         }
     }
 }
-

--- a/contracts/modules/credit/SpigotedLine.sol
+++ b/contracts/modules/credit/SpigotedLine.sol
@@ -99,7 +99,7 @@ contract SpigotedLine is ISpigotedLine, LineOfCredit, ReentrancyGuard {
         bytes32 id = ids[0];
         Credit memory credit = _accrue(credits[id], id);
 
-        if (msg.sender != borrower && msg.sender != credit.lender) {
+        if (msg.sender != arbiter) {
             revert CallerAccessDenied();
         }
 
@@ -137,9 +137,11 @@ contract SpigotedLine is ISpigotedLine, LineOfCredit, ReentrancyGuard {
     function useAndRepay(uint256 amount) external whileBorrowing returns(bool) {
       bytes32 id = ids[0];
       Credit memory credit = credits[id];
+      
       if (msg.sender != borrower && msg.sender != credit.lender) {
         revert CallerAccessDenied();
       }
+
       require(amount <= unusedTokens[credit.token]);
       unusedTokens[credit.token] -= amount;
 
@@ -157,7 +159,9 @@ contract SpigotedLine is ISpigotedLine, LineOfCredit, ReentrancyGuard {
         nonReentrant
         returns (uint256)
     {
-        require(msg.sender == borrower);
+        if (msg.sender != arbiter) {
+            revert CallerAccessDenied();
+        }
 
         address targetToken = credits[ids[0]].token;
         uint256 newTokens = claimToken == targetToken ?
@@ -225,9 +229,11 @@ contract SpigotedLine is ISpigotedLine, LineOfCredit, ReentrancyGuard {
         ISpigot.Setting calldata setting
     )
         external
-        mutualConsent(arbiter, borrower)
         returns (bool)
     {
+        if (msg.sender != arbiter) {
+            revert CallerAccessDenied();
+        }
         return spigot.addSpigot(revenueContract, setting);
     }
 
@@ -236,7 +242,9 @@ contract SpigotedLine is ISpigotedLine, LineOfCredit, ReentrancyGuard {
         external
         returns (bool)
     {
-        require(msg.sender == arbiter);
+        if (msg.sender != arbiter) {
+            revert CallerAccessDenied();
+        }
         return spigot.updateWhitelistedFunction(func, allowed);
     }
 


### PR DESCRIPTION
- changes access control on `claimAndRepay` and `claimAndTrade` to just`arbiter` role as a neutral 3rd party preventing toxc orders from lenders or borrowers to cyphon funds
- Retains access control over useAndRepay since that does not expose 0x interface
- remove mutualConsent from `addSpigot`, only requires Arbiter for simpler UX.
- replace require with null reason string with custom error in `addSpigot`