### PR TITLE
change '> 0' with '!= 0' for cheaper gas uint eval

### DIFF
--- a/contracts/modules/credit/LineOfCredit.sol
+++ b/contracts/modules/credit/LineOfCredit.sol
@@ -133,7 +133,7 @@ contract LineOfCredit is ILineOfCredit, MutualConsent, ReentrancyGuard {
         }
 
         // Liquidate if all credit lines aren't closed by deadline
-        if (block.timestamp >= deadline && count > 0) {
+        if (block.timestamp >= deadline && count != 0) {
             emit Default(ids[0]); // can query all defaulted positions offchain once event picked up
             return LineLib.STATUS.LIQUIDATABLE;
         }
@@ -501,7 +501,7 @@ contract LineOfCredit is ILineOfCredit, MutualConsent, ReentrancyGuard {
                 if (
                     id == bytes32(0) || // deleted element. In the middle of the q because it was closed.
                     nextQSpot != lastSpot || // position already found. skip to find `p` asap
-                    credits[id].principal > 0 //`id` should be placed before `p`
+                    credits[id].principal != 0 //`id` should be placed before `p`
                 ) continue;
                 nextQSpot = i; // index of first undrawn line found
             } else {

--- a/contracts/utils/EscrowLib.sol
+++ b/contracts/utils/EscrowLib.sol
@@ -81,7 +81,7 @@ library EscrowLib {
         uint256 amount,
         address token
     ) external returns (uint256) {
-        require(amount > 0);
+        require(amount != 0);
         if (!self.enabled[token]) {
             revert InvalidCollateral();
         }
@@ -109,7 +109,7 @@ library EscrowLib {
             } else {
                 (bool passed, bytes memory tokenAddrBytes) = token.call(abi.encodeWithSignature("asset()"));
 
-                bool is4626 = tokenAddrBytes.length > 0 && passed;
+                bool is4626 = tokenAddrBytes.length != 0 && passed;
                 deposit.isERC4626 = is4626;
                 // if 4626 save the underlying token to use for oracle pricing
                 deposit.asset = !is4626 ? token : abi.decode(tokenAddrBytes, (address));
@@ -122,7 +122,7 @@ library EscrowLib {
                 (bool successDecimals, bytes memory decimalBytes) = deposit.asset.call(
                     abi.encodeWithSignature("decimals()")
                 );
-                if (decimalBytes.length > 0 && successDecimals) {
+                if (decimalBytes.length != 0 && successDecimals) {
                     deposit.assetDecimals = abi.decode(decimalBytes, (uint8));
                 } else {
                     deposit.assetDecimals = 18;
@@ -149,7 +149,7 @@ library EscrowLib {
         address token,
         address to
     ) external returns (uint256) {
-        require(amount > 0);
+        require(amount != 0);
         if (msg.sender != borrower) {
             revert CallerAccessDenied();
         }
@@ -187,7 +187,7 @@ library EscrowLib {
 
     /** see Escrow.liquidate */
     function liquidate(EscrowState storage self, uint256 amount, address token, address to) external returns (bool) {
-        require(amount > 0);
+        require(amount != 0);
         if (msg.sender != self.line) {
             revert CallerAccessDenied();
         }

--- a/contracts/utils/LineLib.sol
+++ b/contracts/utils/LineLib.sol
@@ -70,7 +70,7 @@ library LineLib {
         }
         if (token != Denominations.ETH) {
             // ERC20
-            if (msg.value > 0) {
+            if (msg.value != 0) {
                 revert EthSentWithERC20();
             }
             IERC20(token).safeTransferFrom(sender, address(this), amount);


### PR DESCRIPTION
More gas efficient check that value is correct. Only works for `uint`s not `int`s

All tests pass